### PR TITLE
6.15.7-2-adoptopenjdk8 deal with additional param in gen_cfg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN sed -i '/org.apache.catalina.valves.StuckThreadDetectionValve/{N;s/threshold
 
 RUN chown -R 2002:2002 ${CONFLUENCE_HOME}
 
+# Atlassian's gen_cfg and our gen_cfg_no_chown should have the same signature
+# Fail the build if that's not the case
+COPY bin/check_signatures.sh /
+RUN chmod +x /check_signatures.sh && /check_signatures.sh
+
 USER 2002
 
 CMD ["/entrypoint.py", "-fg"]

--- a/bin/check_signatures.sh
+++ b/bin/check_signatures.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Atlassian's gen_cfg and our gen_cfg_no_chown should have the same signature
+# Fail the build if that's not the case
+# Note that we can't use Python's inspect module here to check the signature very easily because /entrypoint.py cannot be imported without starting the service
+diff <(grep 'def gen_cfg' /entrypoint.py) <(grep 'def gen_cfg' /hardening.py | sed 's/gen_cfg_no_chown/gen_cfg/')


### PR DESCRIPTION
The Atlassian docker image 6.15.7-adoptopenjdk8 got updated and retagged with the same version..
The signature to method gen_cfg in entrypoint.py got changed, which makes the modified entrypoint fail.

So modified the signature of our method gen_cfg_no_chown to match the new signature of gen_cfg and added a test that will fail the docker build if this happens again in future